### PR TITLE
Addressing security vulnerabilities in the remarkable package swagger editor depends on

### DIFF
--- a/portal/craco.config.js
+++ b/portal/craco.config.js
@@ -1,4 +1,5 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin')
+const cspHtmlWebpackPlugin = require('csp-html-webpack-plugin')
 const config = require('./config.json')
 
 const templateParametersGenerator = existingGenerator => (
@@ -11,6 +12,14 @@ const templateParametersGenerator = existingGenerator => (
     ...existingGenerator(compilation, assets, assetTags, options),
     favicon: config.favicon || '%PUBLIC_URL%/favicon.png',
   }
+}
+
+const cspConfigPolicy = {
+  'default-src': "'none'",
+  'base-uri': "'self'",
+  'object-src': "'none'",
+  'script-src': ["'self'"],
+  'style-src': ["'self'"],
 }
 
 module.exports = {
@@ -65,6 +74,10 @@ module.exports = {
 
         return plugin
       })
+
+      if (env === 'production') {
+        webpackConfig.plugins.push(new cspHtmlWebpackPlugin(cspConfigPolicy))
+      }
 
       return webpackConfig
     },

--- a/portal/package.json
+++ b/portal/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "apidocs",
+  "name": "apydox",
   "version": "0.1.0",
   "private": true,
   "dependencies": {
@@ -68,7 +68,8 @@
     "babel-jest": "24.7.1",
     "lodash": "4.17.13",
     "lodash.mergewith": "4.6.2",
-    "underscore.string": "3.3.5"
+    "underscore.string": "3.3.5",
+    "remarkable": "freshwebio/remarkable#fix-redos"
   },
   "devDependencies": {
     "@types/enzyme": "^3.9.1",
@@ -80,6 +81,7 @@
     "@typescript-eslint/eslint-plugin": "^1.7.0",
     "@typescript-eslint/parser": "^1.7.0",
     "codacy-coverage": "^3.4.0",
+    "csp-html-webpack-plugin": "^3.0.2",
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.12.1",
     "eslint-config-prettier": "^4.2.0",

--- a/portal/yarn.lock
+++ b/portal/yarn.lock
@@ -1662,18 +1662,12 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
-argparse@^1.0.7:
+argparse@^1.0.10, argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
-
-argparse@~0.1.15:
-  version "0.1.16"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-0.1.16.tgz#cfd01e0fbba3d6caed049fbd758d40f65196f57c"
-  dependencies:
-    underscore "~1.7.0"
-    underscore.string "~2.4.0"
 
 aria-query@^3.0.0:
   version "3.0.0"
@@ -1848,9 +1842,12 @@ attr-accept@^1.0.3:
   dependencies:
     core-js "^2.5.0"
 
-autolinker@~0.15.0:
-  version "0.15.3"
-  resolved "https://registry.yarnpkg.com/autolinker/-/autolinker-0.15.3.tgz#342417d8f2f3461b14cf09088d5edf8791dc9832"
+autolinker@~0.28.0:
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/autolinker/-/autolinker-0.28.1.tgz#0652b491881879f0775dace0cdca3233942a4e47"
+  integrity sha1-BlK0kYgYefB3XazgzcoyM5QqTkc=
+  dependencies:
+    gulp-header "^1.7.1"
 
 autoprefixer@^9.4.9:
   version "9.5.1"
@@ -2690,6 +2687,13 @@ concat-stream@^1.5.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
+concat-with-sourcemaps@*:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz#d4ea93f05ae25790951b99e7b3b09e3908a4082e"
+  integrity sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==
+  dependencies:
+    source-map "^0.6.1"
+
 confusing-browser-globals@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.7.tgz#5ae852bd541a910e7ffb2dbb864a2d21a36ad29b"
@@ -2879,6 +2883,15 @@ crypto-browserify@^3.11.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
+
+csp-html-webpack-plugin@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/csp-html-webpack-plugin/-/csp-html-webpack-plugin-3.0.2.tgz#46589d9c1622968af3d279a3a3ce64de4c7fa4e4"
+  integrity sha512-78aCKk1GMJN0j63VG7BOeybFbYgV3pZtCWYITHBhUG9m4GbiHDV1NRiQrPogQSoDplDyjuuX6vejgloPbA2pJQ==
+  dependencies:
+    cheerio "^1.0.0-rc.2"
+    lodash "^4.17.11"
+    memory-fs "^0.4.1"
 
 css-blank-pseudo@^0.1.4:
   version "0.1.4"
@@ -4560,6 +4573,15 @@ growly@^1.3.0:
 gud@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
+
+gulp-header@^1.7.1:
+  version "1.8.12"
+  resolved "https://registry.yarnpkg.com/gulp-header/-/gulp-header-1.8.12.tgz#ad306be0066599127281c4f8786660e705080a84"
+  integrity sha512-lh9HLdb53sC7XIZOYzTXM4lFuXElv3EVkSDhsd7DoJBj7hm+Ni7D3qYbb+Rr8DuM8nRanBvkVO9d7askreXGnQ==
+  dependencies:
+    concat-with-sourcemaps "*"
+    lodash.template "^4.4.0"
+    through2 "^2.0.0"
 
 gzip-size@5.0.0:
   version "5.0.0"
@@ -8776,12 +8798,12 @@ relateurl@0.2.x:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
 
-remarkable@^1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/remarkable/-/remarkable-1.7.1.tgz#aaca4972100b66a642a63a1021ca4bac1be3bff6"
+remarkable@^1.7.1, remarkable@freshwebio/remarkable#fix-redos:
+  version "1.7.0"
+  resolved "https://codeload.github.com/freshwebio/remarkable/tar.gz/49a8485ac5397ccaa827c55927f15e40026d8361"
   dependencies:
-    argparse "~0.1.15"
-    autolinker "~0.15.0"
+    argparse "^1.0.10"
+    autolinker "~0.28.0"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
@@ -10016,17 +10038,13 @@ uglify-js@^3.1.4:
     commander "~2.20.0"
     source-map "~0.6.1"
 
-underscore.string@3.3.5, underscore.string@~2.4.0:
+underscore.string@3.3.5:
   version "3.3.5"
   resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-3.3.5.tgz#fc2ad255b8bd309e239cbc5816fd23a9b7ea4023"
   integrity sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==
   dependencies:
     sprintf-js "^1.0.3"
     util-deprecate "^1.0.2"
-
-underscore@~1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.7.0.tgz#6bbaf0877500d36be34ecaa584e0db9fef035209"
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Added CSP for production build to protect against XSS vulnerability in remarkable and pointed to forked version of remarkable with redos vulnerability fix